### PR TITLE
Update apt sources before attempting to install from them.

### DIFF
--- a/oy
+++ b/oy
@@ -35,6 +35,7 @@ function setup_oy {
 	get https://github.com/omerk/mongoose/archive/4.0.tar.gz mongoose.tar.gz
 
 	pinfo "Installing libevent (for webdis) and build-essential"
+	sudo apt-get update
 	sudo apt-get -y install build-essential libevent-dev
 
 	pinfo "Building redis"


### PR DESCRIPTION
On my Raspberry Pi, the sources were out of date so the setup failed.
This fixes that.
